### PR TITLE
OFS-91: updated/upgraded 'delete' mutation and added 'replace' mutation

### DIFF
--- a/policyholder/qgl/gql_mutations/base_mutation.py
+++ b/policyholder/qgl/gql_mutations/base_mutation.py
@@ -66,7 +66,7 @@ class BaseReplaceMutation(BaseMutation):
         if "uuid" in data:
           try:
               cls._validate_mutation(user, **data)
-              mutation_result = cls._mutate(user, **data)
+              mutation_result = cls._mutate(user, uuid=data["uuid"])
               return mutation_result
           except Exception as exc:
               return [{
@@ -226,7 +226,7 @@ class BaseHistoryModelUpdateMutationMixin:
 
     @classmethod
     def update_object(cls, user, object_to_update):
-        object_to_update.save(user.username)
+        object_to_update.save(username=user.username)
         return object_to_update
 
 
@@ -255,7 +255,7 @@ class BaseHistoryModelDeleteMutationMixin:
         if object_to_delete is None:
             cls._object_not_exist_exception(uuid)
         else:
-            object_to_delete.delete(user.username)
+            object_to_delete.delete(username=user.username)
 
 
 class BaseHistoryModelReplaceMutationMixin:
@@ -279,8 +279,7 @@ class BaseHistoryModelReplaceMutationMixin:
     @classmethod
     def _mutate(cls, user, uuid):
         object_to_replace = cls._model.objects.filter(id=uuid).first()
-
         if object_to_replace is None:
             cls._object_not_exist_exception(uuid)
         else:
-            object_to_replace.replace(user.username)
+            object_to_replace.replace_object(username=user.username)

--- a/policyholder/qgl/gql_mutations/delete_mutations.py
+++ b/policyholder/qgl/gql_mutations/delete_mutations.py
@@ -1,6 +1,5 @@
 from policyholder.models import PolicyHolder, PolicyHolderInsuree, PolicyHolderContributionPlan, PolicyHolderUser
-from policyholder.qgl.gql_mutations import PolicyHolderInputType, PolicyHolderInsureeInputType, \
-    PolicyHolderContributionPlanInputType, PolicyHolderUserInputType
+from policyholder.qgl.gql_mutations import PolicyHolderDeleteInputType
 from policyholder.qgl.gql_mutations.base_mutation import BaseDeleteMutation, BaseHistoryModelDeleteMutationMixin
 
 
@@ -8,7 +7,7 @@ class DeletePolicyHolderMutation(BaseHistoryModelDeleteMutationMixin, BaseDelete
     _mutation_class = "PolicyHolderMutation"
     _model = PolicyHolder
 
-    class Input(PolicyHolderInputType):
+    class Input(PolicyHolderDeleteInputType):
         pass
 
 
@@ -16,7 +15,7 @@ class DeletePolicyHolderInsureeMutation(BaseHistoryModelDeleteMutationMixin, Bas
     _mutation_class = "PolicyHolderInsureeMutation"
     _model = PolicyHolderInsuree
 
-    class Input(PolicyHolderInsureeInputType):
+    class Input(PolicyHolderDeleteInputType):
         pass
 
 
@@ -24,7 +23,7 @@ class DeletePolicyHolderContributionPlanMutation(BaseHistoryModelDeleteMutationM
     _mutation_class = "PolicyHolderContributionPlanMutation"
     _model = PolicyHolderContributionPlan
 
-    class Input(PolicyHolderContributionPlanInputType):
+    class Input(PolicyHolderDeleteInputType):
         pass
 
 
@@ -32,6 +31,6 @@ class DeletePolicyHolderUserMutation(BaseHistoryModelDeleteMutationMixin, BaseDe
     _mutation_class = "PolicyHolderUserMutation"
     _model = PolicyHolderUser
 
-    class Input(PolicyHolderUserInputType):
+    class Input(PolicyHolderDeleteInputType):
         pass
 

--- a/policyholder/qgl/gql_mutations/input_types.py
+++ b/policyholder/qgl/gql_mutations/input_types.py
@@ -54,4 +54,4 @@ class PolicyHolderDeleteInputType(OpenIMISMutation.Input):
 
 
 class PolicyHolderReplaceInputType(OpenIMISMutation.Input):
-    uuids = graphene.UUID(required=True)
+    uuid = graphene.UUID(required=True)

--- a/policyholder/qgl/gql_mutations/input_types.py
+++ b/policyholder/qgl/gql_mutations/input_types.py
@@ -47,3 +47,7 @@ class PolicyHolderUserInputType(OpenIMISMutation.Input):
     policy_holder_id = graphene.UUID(required=False)
 
     json_ext = graphene.types.json.JSONString(required=False)
+
+
+class PolicyHolderDeleteInputType(OpenIMISMutation.Input):
+    uuids = graphene.List(graphene.UUID)

--- a/policyholder/qgl/gql_mutations/input_types.py
+++ b/policyholder/qgl/gql_mutations/input_types.py
@@ -51,3 +51,7 @@ class PolicyHolderUserInputType(OpenIMISMutation.Input):
 
 class PolicyHolderDeleteInputType(OpenIMISMutation.Input):
     uuids = graphene.List(graphene.UUID)
+
+
+class PolicyHolderReplaceInputType(OpenIMISMutation.Input):
+    uuids = graphene.UUID(required=True)

--- a/policyholder/qgl/gql_mutations/replace_mutation.py
+++ b/policyholder/qgl/gql_mutations/replace_mutation.py
@@ -1,0 +1,35 @@
+from policyholder.models import PolicyHolder, PolicyHolderInsuree, PolicyHolderContributionPlan, PolicyHolderUser
+from policyholder.qgl.gql_mutations import PolicyHolderReplaceInputType
+from policyholder.qgl.gql_mutations.base_mutation import BaseReplaceMutation, BaseHistoryModelReplaceMutationMixin
+
+
+class ReplacePolicyHolderMutation(BaseHistoryModelReplaceMutationMixin, BaseReplaceMutation):
+    _mutation_class = "PolicyHolderMutation"
+    _model = PolicyHolder
+
+    class Input(PolicyHolderReplaceInputType):
+        pass
+
+
+class ReplacePolicyHolderInsureeMutation(BaseHistoryModelReplaceMutationMixin, BaseReplaceMutation):
+    _mutation_class = "PolicyHolderInsureeMutation"
+    _model = PolicyHolderInsuree
+
+    class Input(PolicyHolderReplaceInputType):
+        pass
+
+
+class ReplacePolicyHolderContributionPlanMutation(BaseHistoryModelReplaceMutationMixin, BaseReplaceMutation):
+    _mutation_class = "PolicyHolderContributionPlanMutation"
+    _model = PolicyHolderContributionPlan
+
+    class Input(PolicyHolderReplaceInputType):
+        pass
+
+
+class ReplacePolicyHolderUserMutation(BaseHistoryModelReplaceMutationMixin, BaseReplaceMutation):
+    _mutation_class = "PolicyHolderUserMutation"
+    _model = PolicyHolderUser
+
+    class Input(PolicyHolderReplaceInputType):
+        pass

--- a/policyholder/schema.py
+++ b/policyholder/schema.py
@@ -9,6 +9,9 @@ from policyholder.qgl.gql_mutations.delete_mutations import DeletePolicyHolderMu
     DeletePolicyHolderInsureeMutation, DeletePolicyHolderUserMutation, DeletePolicyHolderContributionPlanMutation
 from policyholder.qgl.gql_mutations.update_mutations import UpdatePolicyHolderMutation, \
     UpdatePolicyHolderInsureeMutation, UpdatePolicyHolderUserMutation, UpdatePolicyHolderContributionPlanMutation
+from policyholder.qgl.gql_mutations.replace_mutation import ReplacePolicyHolderMutation, ReplacePolicyHolderInsureeMutation, \
+    ReplacePolicyHolderContributionPlanMutation, ReplacePolicyHolderUserMutation
+
 
 from policyholder.qgl.gql_types import PolicyHolderUserGQLType, PolicyHolderGQLType, PolicyHolderInsureeGQLType, \
     PolicyHolderContributionPlanGQLType
@@ -51,3 +54,8 @@ class Mutation(graphene.ObjectType):
     delete_policy_holder_insuree = DeletePolicyHolderInsureeMutation.Field()
     delete_policy_holder_user = DeletePolicyHolderUserMutation.Field()
     delete_policy_holder_contribution_plan_bundle = DeletePolicyHolderContributionPlanMutation.Field()
+
+    replace_policy_holder = ReplacePolicyHolderMutation.Field()
+    replace_policy_holder_insuree = ReplacePolicyHolderInsureeMutation.Field()
+    replace_policy_holder_user = ReplacePolicyHolderUserMutation.Field()
+    replace_policy_holder_contribution_plan_bundle = ReplacePolicyHolderContributionPlanMutation.Field()


### PR DESCRIPTION
In that pull request I want to merge finished 'delete' mutation and newly added 'replace' mutation. 

After that merrge we'll have queries (Search) and mutations:
- Create
- Update
- Delete
- Replace

Obviosly I'll migrate that base mutation file into Core in ticket OFS-88 which as I mentioned earlier I had to suspend this ticket so as to first deliver PolicyHolder backend module for @rstencel. 