### PR TITLE
OFS-99: adding dateValidTo and dateValidFrom to another models

### DIFF
--- a/policyholder/gql/gql_mutations/input_types.py
+++ b/policyholder/gql/gql_mutations/input_types.py
@@ -48,22 +48,24 @@ class PolicyHolderInsureeInputType(OpenIMISMutation.Input):
     insuree_id = graphene.Int(required=False, name="insureeId")
     contribution_plan_bundle_id = graphene.UUID(requried=False, name="contributionPlanBundleId")
     last_policy_id = graphene.Int(required=False, name="lastPolicyId")
+    date_valid_from = graphene.Date(required=False)
+    date_valid_to = graphene.Date(required=False)
     json_ext = graphene.types.json.JSONString(required=False)
 
 
 class PolicyHolderContributionPlanInputType(OpenIMISMutation.Input):
     id = graphene.UUID(required=False)
-
     policy_holder_id = graphene.UUID(required=False)
     contribution_plan_bundle_id = graphene.UUID(requried=False, name="contributionPlanBundleId")
-
+    date_valid_from = graphene.Date(required=False)
+    date_valid_to = graphene.Date(required=False)
     json_ext = graphene.types.json.JSONString(required=False)
 
 
 class PolicyHolderUserInputType(OpenIMISMutation.Input):
     id = graphene.UUID(required=False)
-
     user_id = graphene.UUID(required=False)
     policy_holder_id = graphene.UUID(required=False)
-
+    date_valid_from = graphene.Date(required=False)
+    date_valid_to = graphene.Date(required=False)
     json_ext = graphene.types.json.JSONString(required=False)


### PR DESCRIPTION
I forgot about allowing user to put as an input dateValidTo and dateValidFrom in another models in PolicyHolder. Please also merge this. Thx. 