### PR TITLE
OFS-104: fixing lack of importing Q in policyholder schema

### DIFF
--- a/policyholder/schema.py
+++ b/policyholder/schema.py
@@ -1,6 +1,7 @@
 import graphene
 import graphene_django_optimizer as gql_optimizer
 
+from django.db.models import Q
 from location.apps import LocationConfig
 from core.schema import OrderedDjangoFilterConnectionField
 from policyholder.models import PolicyHolder, PolicyHolderInsuree, PolicyHolderUser, PolicyHolderContributionPlan


### PR DESCRIPTION
Please merge this change because there was lack of Q in import statements in PolicyHolder schema.  