### PR TITLE
OFS-120: permissions in app.py etc and update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # openIMIS Backend PolicyHolder reference module
+This repository holds the files of the openIMIS Backend PolicyHolder reference module.
+It is dedicated to be deployed as a module of [openimis-be_py](https://github.com/openimis/openimis-be_py).
+
+## ORM mapping:
+* tblPolicyHolder  > PolicyHolder 
+* tblPolicyHolderInsuree > PolicyHolderInsuree
+* tblPolicyHolderContributionPlanBundle  > PolicyHolderContributionPlanBundle
+* tblPolicyHolderUser > PolicyHolderUser
+
+## GraphQL Queries
+* policyHolder
+* PolicyHolderInsuree
+* PolicyHolderContributionPlanBundle
+* PolicyHolderUser
+
+## GraphQL Mutations - each mutation emits default signals and return standard error lists (cfr. openimis-be-core_py)
+* createPolicyHolder
+* updatePolicyHolder
+* deletePolicyHolder
+* createPolicyHolderInsuree
+* updatePolicyHolderInsuree
+* deletePolicyHolderInsuree
+* replacePolicyHolderInsuree
+* createPolicyHolderContributionPlanBundle
+* updatePolicyHolderContributionPlanBundle
+* deletePolicyHolderContributionPlanBundle
+* replacePolicyHolderContributionPlanBundle
+* createPolicyHolderUser
+* updatePolicyHolderUser
+* deletePolicyHolderUser
+* replacePolicyHolderUser
+
+## Services
+* PolicyHolder - CRUD services 
+* PolicyHolderInsuree - CRUD services, replacePolicyHolderInsuree
+* PolicyHolderContributionPlanBundle - CRUD services, replacePoicyHolderContributionPlanBundle
+* PolicyHolderUser - CRUD services, replacePolicyHolderUser
+
+## Configuration options (can be changed via core.ModuleConfiguration)
+* gql_query_policyholder_perms: required rights to call policy_holder GraphQL Query (default: ["150101"])
+* gql_query_policyholder_admins_perms: required rights to call policy_holder_admin GraphQL Query (default: [])
+* gql_query_policyholderinsuree_perms: required rights to call policy_holder_insuree GraphQL Query (default: ["150201"])
+* gql_query_policyholderinsuree_admins_perms: required rights to call policy_holder_insuree_admin GraphQL Query (default: [])
+* gql_query_policyholderuser_perms: required rights to call policy_holder_user GraphQL Query (default: ["150301"])
+* gql_query_policyholderuser_admins_perms: required rights to call policy_holder_user_admin GraphQL Query (default: [])
+* gql_query_policyholdercontributionplanbundle_perms: required rights to call policy_holder_contribution_plan_bundle GraphQL Query (default: ["150401"])
+* gql_query_policyholdercontributionplanbundle_admins_perms: required rights to call policy_holder_contribution_plan_bundle_admin GraphQL Query (default: [])
+
+* gql_mutation_create_policyholder_perms: required rights to call createPolicyHolder GraphQL Mutation (default: ["150102"])
+* gql_mutation_update_policyholder_perms: required rights to call updatePolicyHolder GraphQL Mutation (default: ["150103"])
+* gql_mutation_delete_policyholder_perms: required rights to call deletePolicyHolder GraphQL Mutation (default: ["150104"])
+   
+* gql_mutation_create_policyholderinsuree_perms: required rights to call createPolicyHolderInsuree GraphQL Mutation (default: ["150202"]),
+* gql_mutation_update_policyholderinsuree_perms: required rights to call updatePolicyHolderInsuree GraphQL Mutation (default: ["150203"]),
+* gql_mutation_delete_policyholderinsuree_perms: required rights to call deletePolicyHolderInsuree GraphQL Mutation (default: ["150204"]),
+* gql_mutation_replace_policyholderinsuree_perms: required rights to call replacePolicyHolderInsuree GraphQL Mutation (default: ["150206"]),
+    
+* gql_mutation_create_policyholderuser_perms: required rights to call createPolicyHolderUser GraphQL Mutation (default: ["150302"]),
+* gql_mutation_update_policyholderuser_perms: required rights to call updatePolicyHolderUser GraphQL Mutation (default: ["150303"]),
+* gql_mutation_delete_policyholderuser_perms: required rights to call deletePolicyHolderUser GraphQL Mutation (default: ["150304"]),
+* gql_mutation_replace_policyholderuser_perms: required rights to call replacePolicyHolderUser GraphQL Mutation (default: ["150306"]),
+    
+* gql_mutation_create_policyholdercontributionplan_perms: required rights to call createPolicyHolderContributionPlanBundle GraphQL Mutation (default: ["150402"]),
+* gql_mutation_update_policyholdercontributionplan_perms: required rights to call updatePolicyHolderContributionPlanBundle GraphQL Mutation (default: ["150403"]),
+* gql_mutation_delete_policyholdercontributionplan_perms: required rights to call deletePolicyHolderContributionPlanBundle GraphQL Mutation (default: ["150404"]),
+* gql_mutation_replace_policyholdercontributionplan_perms: required rights to call replacePolicyHolderContributionPlanBundle GraphQL Mutation (default: ["150406"]),

--- a/policyholder/apps.py
+++ b/policyholder/apps.py
@@ -7,16 +7,12 @@ MODULE_NAME = "policyholder"
 DEFAULT_CFG = {
     "gql_query_policyholder_perms": ["150101"],
     "gql_query_policyholder_admins_perms": [],
-    "gql_query_policyholder_officers_perms": [],
     "gql_query_policyholderinsuree_perms": ["150201"],
     "gql_query_policyholderinsuree_admins_perms": [],
-    "gql_query_policyholderinsuree_officers_perms": [],
     "gql_query_policyholderuser_perms": ["150301"],
     "gql_query_policyholderuser_admins_perms": [],
-    "gql_query_policyholderuser_officers_perms": [],
     "gql_query_policyholdercontributionplanbundle_perms": ["150401"],
     "gql_query_policyholdercontributionplanbundle_admins_perms": [],
-    "gql_query_policyholdercontributionplanbundle_officers_perms": [],
     "gql_mutation_create_policyholder_perms": ["150102"],
     "gql_mutation_update_policyholder_perms": ["150103"],
     "gql_mutation_delete_policyholder_perms": ["150104"],
@@ -40,16 +36,12 @@ class PolicyholderConfig(AppConfig):
 
     gql_query_policyholder_perms = []
     gql_query_policyholder_admins_perms = []
-    gql_query_policyholder_officers_perms = []
     gql_query_policyholderinsuree_perms = []
     gql_query_policyholderinsuree_admins_perms = []
-    gql_query_policyholderinsuree_officers_perms = []
     gql_query_policyholderuser_perms = []
     gql_query_policyholderuser_admins_perms = []
-    gql_query_policyholderuser_officers_perms = []
     gql_query_policyholdercontributionplanbundle_perms = []
     gql_query_policyholdercontributionplanbundle_admins_perms = []
-    gql_query_policyholdercontributionplanbundle_officers_perms = []
     gql_mutation_create_policyholder_perms = []
     gql_mutation_update_policyholder_perms = []
     gql_mutation_delete_policyholder_perms = []
@@ -71,37 +63,24 @@ class PolicyholderConfig(AppConfig):
             "gql_query_policyholder_perms"]
         PolicyholderConfig.gql_query_policyholder_admins_perms = cfg[
             "gql_query_policyholder_admins_perms"]
-        PolicyholderConfig.gql_query_policyholder_officers_perms = cfg[
-            "gql_query_policyholder_officers_perms"]
-
         PolicyholderConfig.gql_query_policyholderinsuree_perms = cfg[
             "gql_query_policyholderinsuree_perms"]
         PolicyholderConfig.gql_query_policyholderinsuree_admins_perms = cfg[
             "gql_query_policyholderinsuree_admins_perms"]
-        PolicyholderConfig.gql_query_policyholderuser_officers_perms = cfg[
-            "gql_query_policyholderuser_officers_perms"]
-
         PolicyholderConfig.gql_query_policyholderuser_perms = cfg[
             "gql_query_policyholderuser_perms"]
         PolicyholderConfig.gql_query_policyholderuser_admins_perms = cfg[
             "gql_query_policyholderuser_admins_perms"]
-        PolicyholderConfig.gql_query_policyholderuser_officers_perms = cfg[
-            "gql_query_policyholderuser_officers_perms"]
-
         PolicyholderConfig.gql_query_policyholdercontributionplanbundle_perms = cfg[
             "gql_query_policyholdercontributionplanbundle_perms"]
         PolicyholderConfig.gql_query_policyholdercontributionplanbundle_admins_perms = cfg[
             "gql_query_policyholdercontributionplanbundle_admins_perms"]
-        PolicyholderConfig.gql_query_policyholdercontributionplanbundle_officers_perms = cfg[
-            "gql_query_policyholdercontributionplanbundle_officers_perms"]
-
         PolicyholderConfig.gql_mutation_create_policyholder_perms = cfg[
             "gql_mutation_create_policyholder_perms"]
         PolicyholderConfig.gql_mutation_update_policyholder_perms = cfg[
             "gql_mutation_update_policyholder_perms"]
         PolicyholderConfig.gql_mutation_delete_policyholder_perms = cfg[
             "gql_mutation_delete_policyholder_perms"]
-
         PolicyholderConfig.gql_mutation_create_policyholderinsuree_perms = cfg[
             "gql_mutation_create_policyholderinsuree_perms"]
         PolicyholderConfig.gql_mutation_update_policyholderinsuree_perms = cfg[
@@ -110,7 +89,6 @@ class PolicyholderConfig(AppConfig):
             "gql_mutation_delete_policyholderinsuree_perms"]
         PolicyholderConfig.gql_mutation_replace_policyholderinsuree_perms = cfg[
             "gql_mutation_replace_policyholderinsuree_perms"]
-
         PolicyholderConfig.gql_mutation_create_policyholderuser_perms = cfg[
             "gql_mutation_create_policyholderuser_perms"]
         PolicyholderConfig.gql_mutation_update_policyholderuser_perms = cfg[
@@ -119,7 +97,6 @@ class PolicyholderConfig(AppConfig):
             "gql_mutation_delete_policyholderuser_perms"]
         PolicyholderConfig.gql_mutation_replace_policyholderuser_perms = cfg[
             "gql_mutation_replace_policyholderuser_perms"]
-
         PolicyholderConfig.gql_mutation_create_policyholdercontributionplan_perms = cfg[
             "gql_mutation_create_policyholdercontributionplan_perms"]
         PolicyholderConfig.gql_mutation_update_policyholdercontributionplan_perms = cfg[

--- a/policyholder/apps.py
+++ b/policyholder/apps.py
@@ -1,5 +1,135 @@
 from django.apps import AppConfig
 
 
+MODULE_NAME = "policyholder"
+
+
+DEFAULT_CFG = {
+    "gql_query_policyholder_perms": ["150101"],
+    "gql_query_policyholder_admins_perms": [],
+    "gql_query_policyholder_officers_perms": [],
+    "gql_query_policyholderinsuree_perms": ["150201"],
+    "gql_query_policyholderinsuree_admins_perms": [],
+    "gql_query_policyholderinsuree_officers_perms": [],
+    "gql_query_policyholderuser_perms": ["150301"],
+    "gql_query_policyholderuser_admins_perms": [],
+    "gql_query_policyholderuser_officers_perms": [],
+    "gql_query_policyholdercontributionplanbundle_perms": ["150401"],
+    "gql_query_policyholdercontributionplanbundle_admins_perms": [],
+    "gql_query_policyholdercontributionplanbundle_officers_perms": [],
+    "gql_mutation_create_policyholder_perms": ["150102"],
+    "gql_mutation_update_policyholder_perms": ["150103"],
+    "gql_mutation_delete_policyholder_perms": ["150104"],
+    "gql_mutation_create_policyholderinsuree_perms": ["150202"],
+    "gql_mutation_update_policyholderinsuree_perms": ["150203"],
+    "gql_mutation_delete_policyholderinsuree_perms": ["150204"],
+    "gql_mutation_replace_policyholderinsuree_perms": ["150206"],
+    "gql_mutation_create_policyholderuser_perms": ["150302"],
+    "gql_mutation_update_policyholderuser_perms": ["150303"],
+    "gql_mutation_delete_policyholderuser_perms": ["150304"],
+    "gql_mutation_replace_policyholderuser_perms": ["150306"],
+    "gql_mutation_create_policyholdercontributionplan_perms": ["150402"],
+    "gql_mutation_update_policyholdercontributionplan_perms": ["150403"],
+    "gql_mutation_delete_policyholdercontributionplan_perms": ["150404"],
+    "gql_mutation_replace_policyholdercontributionplan_perms": ["150406"],
+}
+
+
 class PolicyholderConfig(AppConfig):
-    name = 'policyholder'
+    name = MODULE_NAME
+
+    gql_query_policyholder_perms = []
+    gql_query_policyholder_admins_perms = []
+    gql_query_policyholder_officers_perms = []
+    gql_query_policyholderinsuree_perms = []
+    gql_query_policyholderinsuree_admins_perms = []
+    gql_query_policyholderinsuree_officers_perms = []
+    gql_query_policyholderuser_perms = []
+    gql_query_policyholderuser_admins_perms = []
+    gql_query_policyholderuser_officers_perms = []
+    gql_query_policyholdercontributionplanbundle_perms = []
+    gql_query_policyholdercontributionplanbundle_admins_perms = []
+    gql_query_policyholdercontributionplanbundle_officers_perms = []
+    gql_mutation_create_policyholder_perms = []
+    gql_mutation_update_policyholder_perms = []
+    gql_mutation_delete_policyholder_perms = []
+    gql_mutation_create_policyholderinsuree_perms = []
+    gql_mutation_update_policyholderinsuree_perms = []
+    gql_mutation_delete_policyholderinsuree_perms = []
+    gql_mutation_replace_policyholderinsuree_perms = []
+    gql_mutation_create_policyholderuser_perms = []
+    gql_mutation_update_policyholderuser_perms = []
+    gql_mutation_delete_policyholderuser_perms = []
+    gql_mutation_replace_policyholderuser_perms = []
+    gql_mutation_create_policyholdercontributionplan_perms = []
+    gql_mutation_update_policyholdercontributionplan_perms = []
+    gql_mutation_delete_policyholdercontributionplan_perms = []
+    gql_mutation_replace_policyholdercontributionplan_perms = []
+
+    def _configure_permissions(self, cfg):
+        PolicyholderConfig.gql_query_policyholder_perms = cfg[
+            "gql_query_policyholder_perms"]
+        PolicyholderConfig.gql_query_policyholder_admins_perms = cfg[
+            "gql_query_policyholder_admins_perms"]
+        PolicyholderConfig.gql_query_policyholder_officers_perms = cfg[
+            "gql_query_policyholder_officers_perms"]
+
+        PolicyholderConfig.gql_query_policyholderinsuree_perms = cfg[
+            "gql_query_policyholderinsuree_perms"]
+        PolicyholderConfig.gql_query_policyholderinsuree_admins_perms = cfg[
+            "gql_query_policyholderinsuree_admins_perms"]
+        PolicyholderConfig.gql_query_policyholderuser_officers_perms = cfg[
+            "gql_query_policyholderuser_officers_perms"]
+
+        PolicyholderConfig.gql_query_policyholderuser_perms = cfg[
+            "gql_query_policyholderuser_perms"]
+        PolicyholderConfig.gql_query_policyholderuser_admins_perms = cfg[
+            "gql_query_policyholderuser_admins_perms"]
+        PolicyholderConfig.gql_query_policyholderuser_officers_perms = cfg[
+            "gql_query_policyholderuser_officers_perms"]
+
+        PolicyholderConfig.gql_query_policyholdercontributionplanbundle_perms = cfg[
+            "gql_query_policyholdercontributionplanbundle_perms"]
+        PolicyholderConfig.gql_query_policyholdercontributionplanbundle_admins_perms = cfg[
+            "gql_query_policyholdercontributionplanbundle_admins_perms"]
+        PolicyholderConfig.gql_query_policyholdercontributionplanbundle_officers_perms = cfg[
+            "gql_query_policyholdercontributionplanbundle_officers_perms"]
+
+        PolicyholderConfig.gql_mutation_create_policyholder_perms = cfg[
+            "gql_mutation_create_policyholder_perms"]
+        PolicyholderConfig.gql_mutation_update_policyholder_perms = cfg[
+            "gql_mutation_update_policyholder_perms"]
+        PolicyholderConfig.gql_mutation_delete_policyholder_perms = cfg[
+            "gql_mutation_delete_policyholder_perms"]
+
+        PolicyholderConfig.gql_mutation_create_policyholderinsuree_perms = cfg[
+            "gql_mutation_create_policyholderinsuree_perms"]
+        PolicyholderConfig.gql_mutation_update_policyholderinsuree_perms = cfg[
+            "gql_mutation_update_policyholderinsuree_perms"]
+        PolicyholderConfig.gql_mutation_delete_policyholderinsuree_perms = cfg[
+            "gql_mutation_delete_policyholderinsuree_perms"]
+        PolicyholderConfig.gql_mutation_replace_policyholderinsuree_perms = cfg[
+            "gql_mutation_replace_policyholderinsuree_perms"]
+
+        PolicyholderConfig.gql_mutation_create_policyholderuser_perms = cfg[
+            "gql_mutation_create_policyholderuser_perms"]
+        PolicyholderConfig.gql_mutation_update_policyholderuser_perms = cfg[
+            "gql_mutation_update_policyholderuser_perms"]
+        PolicyholderConfig.gql_mutation_delete_policyholderuser_perms = cfg[
+            "gql_mutation_delete_policyholderuser_perms"]
+        PolicyholderConfig.gql_mutation_replace_policyholderuser_perms = cfg[
+            "gql_mutation_replace_policyholderuser_perms"]
+
+        PolicyholderConfig.gql_mutation_create_policyholdercontributionplan_perms = cfg[
+            "gql_mutation_create_policyholdercontributionplan_perms"]
+        PolicyholderConfig.gql_mutation_update_policyholdercontributionplan_perms = cfg[
+            "gql_mutation_update_policyholdercontributionplan_perms"]
+        PolicyholderConfig.gql_mutation_delete_policyholdercontributionplan_perms = cfg[
+            "gql_mutation_delete_policyholdercontributionplan_perms"]
+        PolicyholderConfig.gql_mutation_replace_policyholdercontributionplan_perms = cfg[
+            "gql_mutation_replace_policyholdercontributionplan_perms"]
+
+    def ready(self):
+        from core.models import ModuleConfiguration
+        cfg = ModuleConfiguration.get_or_default(MODULE_NAME, DEFAULT_CFG)
+        self._configure_permissions(cfg)


### PR DESCRIPTION
In that pull request I want to add configuration option in apps.py connected with permissions etc. This settings might be loaded from database (ModuleConfiguration from core.models) or by default values.

Moreover I updated readme.md file so as to describe this module etc.

Later I'll add location restrict filtering location by user in the same branch.