### PR TITLE
OFS-156: adding lacking date valid to/from in PHInsuree schema

### DIFF
--- a/policyholder/gql/gql_types.py
+++ b/policyholder/gql/gql_types.py
@@ -53,6 +53,8 @@ class PolicyHolderInsureeGQLType(DjangoObjectType):
             **prefix_filterset("contribution_plan_bundle__", ContributionPlanBundleGQLType._meta.filter_fields),
             "date_created": ["exact", "lt", "lte", "gt", "gte"],
             "date_updated": ["exact", "lt", "lte", "gt", "gte"],
+            "date_valid_from": ["exact", "lt", "lte", "gt", "gte"],
+            "date_valid_to": ["exact", "lt", "lte", "gt", "gte"],
             "user_created": ["exact"],
             "user_updated": ["exact"],
             "is_deleted": ["exact"]


### PR DESCRIPTION
Please merge this for @rstencel - he reported me lack of this elements in filtering (date_valid_from and date_valid_to) in GQLType in PolicyHolder. Thx in advance.