### PR TITLE
OFS-241: changes in test - django test case instead of unittest.TestCase

### DIFF
--- a/policyholder/tests/helpers.py
+++ b/policyholder/tests/helpers.py
@@ -101,7 +101,7 @@ def create_test_policy_holder_user(user=None, policy_holder=None, custom_props={
 
 
 def __get_or_create_simple_policy_holder_user():
-    user = User.objects.get(username="admin")
-    # user, _ = User.objects.get_or_create(username='policy_holder_user',
-    #                                  i_user=InteractiveUser.objects.first())
+    if not User.objects.filter(username='admin').exists():
+        User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+    user = User.objects.filter(username='admin').first()
     return user

--- a/policyholder/tests/helpers_tests.py
+++ b/policyholder/tests/helpers_tests.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from unittest import TestCase
+from django.test import TestCase
 
 from policyholder.models import PolicyHolder, PolicyHolderInsuree, PolicyHolderUser
 from policyholder.tests import create_test_policy_holder, create_test_policy_holder_insuree, \

--- a/policyholder/tests/services/services_ph_tests.py
+++ b/policyholder/tests/services/services_ph_tests.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
+from django.test import TestCase
 
 from django.core.exceptions import ValidationError
-from django.test import TransactionTestCase
 from location.models import Location
 from insuree.models import Insuree
 from policyholder.services import PolicyHolder as PolicyHolderService, PolicyHolderInsuree as PolicyHolderInsureeService, \
@@ -38,8 +37,9 @@ class ServiceTestPolicyHolder(TestCase):
     @classmethod
     def setUpClass(cls):
         PolicyHolder.objects.filter(code=cls.POLICY_HOLDER['code']).delete()
-
-        cls.user = User.objects.get(username="admin")
+        if not User.objects.filter(username='admin').exists():
+            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin').first()
         cls.policy_holder_service = PolicyHolderService(cls.user)
         cls.policy_holder_insuree_service = PolicyHolderInsureeService(cls.user)
         cls.policy_holder_contribution_plan_service = PolicyHolderContributionPlanService(cls.user)


### PR DESCRIPTION
ticket https://openimis.atlassian.net/browse/OFS-241

changes in tests - change the TestCase (from django.TestCase) instead of using unittest.TestCase (to have test in separate test db to not keep records created during test etc)