### PR TITLE
OP-1903: fixed missing signature method for resolving policy holder

### DIFF
--- a/policyholder/schema.py
+++ b/policyholder/schema.py
@@ -77,7 +77,7 @@ class Query(graphene.ObjectType):
         errors = PolicyHolderServices.check_unique_code_policy_holder(code=kwargs['policy_holder_code'])
         return False if errors else True
 
-
+    def resolve_policy_holder(self, info, **kwargs):
         if not info.context.user.has_perms(PolicyholderConfig.gql_query_policyholder_perms):
             raise PermissionDenied(_("unauthorized"))
         filters = []


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-1903

There was an Issue during creation of policyholder. PolicyHolder is created and the older entity was displayed instead of the newly created one. I checked the code and it realized to be a problem with 'gql query' of policyholder where someone by accident remove signature of 'resolve_policy_holder' method in schema.py therefore default resolver was used and 'client mutation id' argument wasn't working in query. 